### PR TITLE
Fix build for Qt5.11+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ doc/build
 *.qm
 qscintilla_*.ts
 *.rc
-
+_build

--- a/src/gui/AboutDialogs.h
+++ b/src/gui/AboutDialogs.h
@@ -21,6 +21,7 @@
 #include <util/ComposerSettings.h>
 using namespace cpr::core;
 
+#include <QAction>
 #include <QDialog>
 #include <QStringListModel>
 #include <QTreeWidget>

--- a/src/plugins/ncl-textual-view/deps/QScintilla_gpl-2.10.1/Qt4Qt5/CMakeLists.txt
+++ b/src/plugins/ncl-textual-view/deps/QScintilla_gpl-2.10.1/Qt4Qt5/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.2)
 project(qscintilla2_telem)
 
-set (CMAKE_AUTOMOC ON)
+set (CMAKE_AUTOMOC OFF)
 set (CMAKE_AUTORCC ON)
 set (CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -23,7 +23,7 @@ set (QSCINTILLA_SOURCES
   ./Qsci/qscicommandset.h
   ./Qsci/qscidocument.h
   ./Qsci/qscilexer.h
-  
+
   ./Qsci/qscilexercustom.h
   ./Qsci/qscilexercpp.h
   ./Qsci/qscilexerpython.h
@@ -31,7 +31,7 @@ set (QSCINTILLA_SOURCES
   ./Qsci/qscilexerhtml.h
   ./Qsci/qscilexerxml.h
   ./Qsci/qscilexerlua.h
-  
+
   ./Qsci/qscimacro.h
   ./Qsci/qsciprinter.h
   ./Qsci/qscistyle.h
@@ -91,7 +91,7 @@ set (QSCINTILLA_SOURCES
   ../src/UniConversion.h
   ../src/ViewStyle.h
   ../src/XPM.h
-  
+
   qsciscintilla.cpp
   qsciscintillabase.cpp
   qsciabstractapis.cpp
@@ -100,7 +100,7 @@ set (QSCINTILLA_SOURCES
   qscicommandset.cpp
   qscidocument.cpp
   qscilexer.cpp
-  
+
   qscilexercustom.cpp
   qscilexercpp.cpp
   qscilexerpython.cpp
@@ -108,7 +108,7 @@ set (QSCINTILLA_SOURCES
   qscilexerhtml.cpp
   qscilexerxml.cpp
   qscilexerlua.cpp
-  
+
   qscimacro.cpp
   qsciprinter.cpp
   qscistyle.cpp
@@ -119,12 +119,12 @@ set (QSCINTILLA_SOURCES
   ListBoxQt.cpp
   PlatQt.cpp
   ScintillaQt.cpp
-  
+
   ../lexers/LexPython.cpp
   ../lexers/LexCPP.cpp
   ../lexers/LexHTML.cpp
   ../lexers/LexLua.cpp
-  
+
   ../lexlib/Accessor.cpp
   ../lexlib/CharacterCategory.cpp
   ../lexlib/CharacterSet.cpp

--- a/src/plugins/ncl-textual-view/deps/QScintilla_gpl-2.10.1/Qt4Qt5/qscintilla.pro
+++ b/src/plugins/ncl-textual-view/deps/QScintilla_gpl-2.10.1/Qt4Qt5/qscintilla.pro
@@ -1,19 +1,19 @@
 # The project file for the QScintilla library.
 #
 # Copyright (c) 2017 Riverbank Computing Limited <info@riverbankcomputing.com>
-# 
+#
 # This file is part of QScintilla.
-# 
+#
 # This file may be used under the terms of the GNU General Public License
 # version 3.0 as published by the Free Software Foundation and appearing in
 # the file LICENSE included in the packaging of this file.  Please review the
 # following information to ensure the GNU General Public License version 3.0
 # requirements will be met: http://www.gnu.org/copyleft/gpl.html.
-# 
+#
 # If you do not wish to use this file under the terms of the GPL version 3.0
 # then you may purchase a commercial license.  For more information contact
 # info@riverbankcomputing.com.
-# 
+#
 # This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 # WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 
@@ -495,6 +495,7 @@ contains(ALL_LEXERS, true) {
 	../src/UniConversion.cpp \
 	../src/ViewStyle.cpp \
 	../src/XPM.cpp
+}
 
 TRANSLATIONS = \
 	qscintilla_cs.ts \


### PR DESCRIPTION
It wasn't compiling for me (ArchLinux, Qt 5.12), so I did some research on how to solve the errors I had. Seems like Qt5.11 broke some obscure things here and there.

**Changes:**
- Fix missing '}' in QScintilla's project file (caught when running `qmake` for `Qt4Qt5`¹ directory);
- Fix error: invalid use of incomplete type 'class QAction';
- Add `_build` to ignore list (since it's mentioned on readme in build process).

¹Full path: `nclcomposer/src/plugins/ncl-textual-view/deps/QScintilla_gpl-2.10.1/Qt4Qt5`.

The spacing changes (trim trailling whitespaces on end of line) were done by my editor automatically on save.

This is probally my first contribution for a project that is not from a close friend, so, please check if it's all ok here, haha. :)